### PR TITLE
parse a `resources` field in `init`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/target/
 **/*.rs.bk
+.#*
+/target/
 Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub struct App {
     pub idle: Option<Idle>,
     /// `init: { $Init }`
     pub init: Option<Init>,
-    /// `resources: $Resources`
+    /// `resources: $Statics`
     pub resources: Option<Statics>,
     /// `tasks: { $Tasks }`
     pub tasks: Option<Tasks>,
@@ -66,6 +66,8 @@ pub struct Idle {
 pub struct Init {
     /// `path: $Path`
     pub path: Option<Path>,
+    /// `resources: $Resources`
+    pub resources: Option<Resources>,
     _extensible: (),
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -170,6 +170,7 @@ fn idle(tts: &mut Peekable<Iter<TokenTree>>) -> Result<Idle> {
 fn init(tts: &mut Peekable<Iter<TokenTree>>) -> Result<Init> {
     ::parse::delimited(tts, DelimToken::Brace, |tts| {
         let mut path = None;
+        let mut resources = None;
 
         ::parse::fields(tts, |key, tts| {
             match key.as_ref() {
@@ -177,6 +178,12 @@ fn init(tts: &mut Peekable<Iter<TokenTree>>) -> Result<Init> {
                     ensure!(path.is_none(), "duplicated `path` field");
 
                     path = Some(::parse::path(tts)?);
+                }
+                "resources" => {
+                    ensure!(resources.is_none(), "duplicated `resources` field");
+
+                    resources = Some(::parse::resources(tts)
+                                     .chain_err(|| "parsing `resources`")?);
                 }
                 _ => bail!("unknown field: `{}`", key),
             }
@@ -187,6 +194,7 @@ fn init(tts: &mut Peekable<Iter<TokenTree>>) -> Result<Init> {
         Ok(Init {
             _extensible: (),
             path,
+            resources,
         })
     })
 }


### PR DESCRIPTION
required for japaric/cortex-m-rtfm#50