### PR TITLE
Fix required for rust-lang #52081

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,10 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(proc_macro)]
+#![feature(use_extern_macros)]
+#![feature(proc_macro_span)]
+#![feature(proc_macro_diagnostic)]
+#![feature(proc_macro_raw_ident)]
 #![feature(try_from)]
 
 extern crate either;


### PR DESCRIPTION
Combined with #8 this allows for compilation on 1.29