### PR TITLE
Remove non-2018 idiomatic extern crate

### DIFF
--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -2,8 +2,6 @@
 #![deny(rust_2018_idioms)]
 #![deny(warnings)]
 
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use rtfm_syntax::Settings;
 


### PR DESCRIPTION
As noted in #23, current rtfm-syntax is non-testable on stable.

This makes rtfm-syntax rust-2018 compliant, however MSRV of 1.36.0 for *testing* breaks.