### PR TITLE
Fix syn version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
-version = "1"
+version = "1.0.12"
 
 [dev-dependencies]
 mock = { path = "mock" }


### PR DESCRIPTION
If building `rtic-syntax` with an old version of syn, it will fail to build due to a missing function `ParseBuffer::span`. When integrating rtic in a fairly dated workspace, I just hit this issue.

To fix it, I bumped the minimum version requirement of syn to 1.0.12, which is when it added the span method.

Ideally, `rtic-syntax` should probably be tested in CI with `-Zminimal-versions` to avoid this sort of problem: https://github.com/rust-lang/cargo/issues/5657

This fixes #42