### PR TITLE
improve error string if parse_binds is not set

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -159,6 +159,13 @@ fn task_args(
 
             let ident_s = ident.to_string();
             match &*ident_s {
+                "binds" if !settings.parse_binds => {
+                    return Err(parse::Error::new(
+                        ident.span(),
+                        "Unexpected bind in task argument. Binds are only parsed if Settings::parse_binds is set.",
+                    ));
+                }
+
                 "binds" if settings.parse_binds => {
                     if binds.is_some() {
                         return Err(parse::Error::new(

--- a/ui/single/task-bind.rs
+++ b/ui/single/task-bind.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+#[mock::app]
+mod app {
+    #[task(binds = UART0)]
+    fn foo(_: foo::Context) {}
+}

--- a/ui/single/task-bind.stderr
+++ b/ui/single/task-bind.stderr
@@ -1,0 +1,5 @@
+error: Unexpected bind in task argument. Binds are only parsed if Settings::parse_binds is set.
+ --> $DIR/task-bind.rs:5:12
+  |
+5 |     #[task(binds = UART0)]
+  |            ^^^^^


### PR DESCRIPTION
When using rtic-syntax as a library and parsing the below

    let (_app, _analysis) = crate::parse2(
        quote!(),
        quote!(
            mod app {
                #[task(binds = UART0)]
                fn foo(_: foo::Context) {}
            }
        ),
        Settings::default(),
    )
    .unwrap();

the user it met with a cryptic Error("unexpected argument"). What is not
obvious is that parse_binds in the Settings struct must be set if binds
are to be parsed.

This commit adds an improved error. Resolves #46.