### PR TITLE
include docs in resources

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -162,6 +162,9 @@ pub struct SharedResource {
     /// `#[cfg]` attributes like `#[cfg(debug_assertions)]`
     pub cfgs: Vec<Attribute>,
 
+    /// `#[doc]` attributes like `/// this is a docstring`
+    pub docs: Vec<Attribute>,
+
     /// Attributes that will apply to this resource
     pub attrs: Vec<Attribute>,
 
@@ -178,6 +181,9 @@ pub struct SharedResource {
 pub struct LocalResource {
     /// `#[cfg]` attributes like `#[cfg(debug_assertions)]`
     pub cfgs: Vec<Attribute>,
+
+    /// `#[doc]` attributes like `/// this is a docstring`
+    pub docs: Vec<Attribute>,
 
     /// Attributes that will apply to this resource
     pub attrs: Vec<Attribute>,

--- a/src/parse/hardware_task.rs
+++ b/src/parse/hardware_task.rs
@@ -1,5 +1,6 @@
 use syn::{parse, ForeignItemFn, ItemFn, Stmt};
 
+use crate::parse::util::FilterAttrs;
 use crate::{
     ast::{HardwareTask, HardwareTaskArgs},
     parse::util,
@@ -24,7 +25,7 @@ impl HardwareTask {
         if valid_signature {
             if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
                 if rest.is_empty() {
-                    let (cfgs, attrs) = util::extract_cfgs(item.attrs);
+                    let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
                     return Ok(HardwareTask {
                         args,
@@ -70,7 +71,7 @@ impl HardwareTask {
         if valid_signature {
             if let Some((context, Ok(rest))) = util::parse_inputs(item.sig.inputs, &name) {
                 if rest.is_empty() {
-                    let (cfgs, attrs) = util::extract_cfgs(item.attrs);
+                    let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
                     return Ok(HardwareTask {
                         args,

--- a/src/parse/monotonic.rs
+++ b/src/parse/monotonic.rs
@@ -2,6 +2,7 @@ use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{parse, spanned::Spanned, ItemType, Visibility};
 
+use crate::parse::util::FilterAttrs;
 use crate::{
     ast::{Monotonic, MonotonicArgs},
     parse::util,
@@ -22,7 +23,7 @@ impl Monotonic {
             ));
         }
 
-        let (cfgs, attrs) = util::extract_cfgs(item.attrs.clone());
+        let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs.clone());
 
         if attrs.len() > 0 {
             return Err(parse::Error::new(

--- a/src/parse/resource.rs
+++ b/src/parse/resource.rs
@@ -1,6 +1,7 @@
 use proc_macro2::Span;
 use syn::{parse, Field, Visibility};
 
+use crate::parse::util::FilterAttrs;
 use crate::{
     ast::{LocalResource, SharedResource, SharedResourceProperties},
     parse::util,
@@ -15,13 +16,18 @@ impl SharedResource {
             ));
         }
 
-        let (cfgs, mut attrs) = util::extract_cfgs(item.attrs.clone());
+        let FilterAttrs {
+            cfgs,
+            mut attrs,
+            docs,
+        } = util::filter_attributes(item.attrs.clone());
 
         let lock_free = util::extract_lock_free(&mut attrs)?;
 
         Ok(SharedResource {
             cfgs,
             attrs,
+            docs,
             ty: Box::new(item.ty.clone()),
             properties: SharedResourceProperties { lock_free },
         })
@@ -37,11 +43,12 @@ impl LocalResource {
             ));
         }
 
-        let (cfgs, attrs) = util::extract_cfgs(item.attrs.clone());
+        let FilterAttrs { cfgs, attrs, docs } = util::filter_attributes(item.attrs.clone());
 
         Ok(LocalResource {
             cfgs,
             attrs,
+            docs,
             ty: Box::new(item.ty.clone()),
         })
     }

--- a/src/parse/software_task.rs
+++ b/src/parse/software_task.rs
@@ -1,5 +1,6 @@
 use syn::{parse, ForeignItemFn, ItemFn, Stmt};
 
+use crate::parse::util::FilterAttrs;
 use crate::{
     ast::{SoftwareTask, SoftwareTaskArgs},
     parse::util,
@@ -16,7 +17,7 @@ impl SoftwareTask {
 
         if valid_signature {
             if let Some((context, Ok(inputs))) = util::parse_inputs(item.sig.inputs, &name) {
-                let (cfgs, attrs) = util::extract_cfgs(item.attrs);
+                let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
                 return Ok(SoftwareTask {
                     args,
@@ -54,7 +55,7 @@ impl SoftwareTask {
 
         if valid_signature {
             if let Some((context, Ok(inputs))) = util::parse_inputs(item.sig.inputs, &name) {
-                let (cfgs, attrs) = util::extract_cfgs(item.attrs);
+                let FilterAttrs { cfgs, attrs, .. } = util::filter_attributes(item.attrs);
 
                 return Ok(SoftwareTask {
                     args,


### PR DESCRIPTION
This is a requirement for fix https://github.com/rtic-rs/cortex-m-rtic/issues/543

- adds `docs` to `{Local/Shared}Resource` so it can be used in codegen.