### PR TITLE
Port macro parsing code to use `syn` crate version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Update syn to v2: Enables Rust Edition 2024
+
 ### Fixed
 
 ## [v1.0.3] - 2023-02-26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
-version = "1.0.12"
+version = "2"
 
 [dev-dependencies]
 mock = { path = "mock" }

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -165,7 +165,7 @@ pub(crate) fn app(app: &App) -> Result<Analysis, syn::Error> {
 
     // Collect errors if any and return/halt
     if !error.is_empty() {
-        let mut err = error.get(0).unwrap().clone();
+        let mut err = error.first().unwrap().clone();
         error.iter().for_each(|e| err.combine(e.clone()));
         return Err(err);
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,12 +7,12 @@ mod resource;
 mod software_task;
 mod util;
 
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use syn::{
-    braced, parenthesized,
+    braced,
     parse::{self, Parse, ParseStream, Parser},
-    token::{self, Brace},
-    Ident, Item, LitBool, LitInt, Path, Token,
+    token::Brace,
+    Ident, Item, LitBool, LitInt, Token,
 };
 
 use crate::{
@@ -74,15 +74,12 @@ fn init_args(tokens: TokenStream2) -> parse::Result<InitArgs> {
 
         let mut local_resources = None;
 
-        let content;
-        parenthesized!(content in input);
-
-        if !content.is_empty() {
+        if !input.is_empty() {
             loop {
                 // Parse identifier name
-                let ident: Ident = content.parse()?;
+                let ident: Ident = input.parse()?;
                 // Handle equal sign
-                let _: Token![=] = content.parse()?;
+                let _: Token![=] = input.parse()?;
 
                 match &*ident.to_string() {
                     "local" => {
@@ -93,18 +90,18 @@ fn init_args(tokens: TokenStream2) -> parse::Result<InitArgs> {
                             ));
                         }
 
-                        local_resources = Some(util::parse_local_resources(&content)?);
+                        local_resources = Some(util::parse_local_resources(input)?);
                     }
                     _ => {
                         return Err(parse::Error::new(ident.span(), "unexpected argument"));
                     }
                 }
 
-                if content.is_empty() {
+                if input.is_empty() {
                     break;
                 }
                 // Handle comma: ,
-                let _: Token![,] = content.parse()?;
+                let _: Token![,] = input.parse()?;
             }
         }
 
@@ -135,14 +132,12 @@ fn idle_args(tokens: TokenStream2) -> parse::Result<IdleArgs> {
         let mut shared_resources = None;
         let mut local_resources = None;
 
-        let content;
-        parenthesized!(content in input);
-        if !content.is_empty() {
+        if !input.is_empty() {
             loop {
                 // Parse identifier name
-                let ident: Ident = content.parse()?;
+                let ident: Ident = input.parse()?;
                 // Handle equal sign
-                let _: Token![=] = content.parse()?;
+                let _: Token![=] = input.parse()?;
 
                 match &*ident.to_string() {
                     "shared" => {
@@ -153,7 +148,7 @@ fn idle_args(tokens: TokenStream2) -> parse::Result<IdleArgs> {
                             ));
                         }
 
-                        shared_resources = Some(util::parse_shared_resources(&content)?);
+                        shared_resources = Some(util::parse_shared_resources(input)?);
                     }
 
                     "local" => {
@@ -164,19 +159,19 @@ fn idle_args(tokens: TokenStream2) -> parse::Result<IdleArgs> {
                             ));
                         }
 
-                        local_resources = Some(util::parse_local_resources(&content)?);
+                        local_resources = Some(util::parse_local_resources(input)?);
                     }
 
                     _ => {
                         return Err(parse::Error::new(ident.span(), "unexpected argument"));
                     }
                 }
-                if content.is_empty() {
+                if input.is_empty() {
                     break;
                 }
 
                 // Handle comma: ,
-                let _: Token![,] = content.parse()?;
+                let _: Token![,] = input.parse()?;
             }
         }
 
@@ -204,17 +199,15 @@ fn task_args(
         let mut local_resources = None;
 
 
-        let content;
-        parenthesized!(content in input);
         loop {
-            if content.is_empty() {
+            if input.is_empty() {
                 break;
             }
 
             // Parse identifier name
-            let ident: Ident = content.parse()?;
+            let ident: Ident = input.parse()?;
             // Handle equal sign
-            let _: Token![=] = content.parse()?;
+            let _: Token![=] = input.parse()?;
 
             let ident_s = ident.to_string();
             match &*ident_s {
@@ -241,7 +234,7 @@ fn task_args(
                     }
 
                     // Parse identifier name
-                    let ident = content.parse()?;
+                    let ident = input.parse()?;
 
                     binds = Some(ident);
                 }
@@ -262,7 +255,7 @@ fn task_args(
                     }
 
                     // #lit
-                    let lit: LitInt = content.parse()?;
+                    let lit: LitInt = input.parse()?;
 
                     if !lit.suffix().is_empty() {
                         return Err(parse::Error::new(
@@ -291,7 +284,7 @@ fn task_args(
                     }
 
                     // #lit
-                    let lit: LitInt = content.parse()?;
+                    let lit: LitInt = input.parse()?;
 
                     if !lit.suffix().is_empty() {
                         return Err(parse::Error::new(
@@ -319,7 +312,7 @@ fn task_args(
                         ));
                     }
 
-                    shared_resources = Some(util::parse_shared_resources(&content)?);
+                    shared_resources = Some(util::parse_shared_resources(input)?);
                 }
 
                 "local" => {
@@ -330,7 +323,7 @@ fn task_args(
                         ));
                     }
 
-                    local_resources = Some(util::parse_local_resources(&content)?);
+                    local_resources = Some(util::parse_local_resources(input)?);
                 }
 
                 _ => {
@@ -338,12 +331,12 @@ fn task_args(
                 }
             }
 
-            if content.is_empty() {
+            if input.is_empty() {
                 break;
             }
 
             // Handle comma: ,
-            let _: Token![,] = content.parse()?;
+            let _: Token![,] = input.parse()?;
         }
         let priority = priority.unwrap_or(1);
         let shared_resources = shared_resources.unwrap_or_default();
@@ -368,28 +361,18 @@ fn task_args(
     .parse2(tokens)
 }
 
-fn monotonic_args(path: Path, tokens: TokenStream2) -> parse::Result<MonotonicArgs> {
+fn monotonic_args(error_loc: Span, tokens: TokenStream2) -> parse::Result<MonotonicArgs> {
     (|input: ParseStream<'_>| -> parse::Result<MonotonicArgs> {
         let mut binds = None;
         let mut priority = None;
         let mut default = None;
 
-        if !input.peek(token::Paren) {
-            return Err(parse::Error::new(
-                path.segments.first().unwrap().ident.span(),
-                "expected opening ( in #[monotonic( ... )]",
-            ));
-        }
-
-        let content;
-        parenthesized!(content in input);
-
-        if !content.is_empty() {
+        if !input.is_empty() {
             loop {
                 // Parse identifier name
-                let ident: Ident = content.parse()?;
+                let ident: Ident = input.parse()?;
                 // Handle equal sign
-                let _: Token![=] = content.parse()?;
+                let _: Token![=] = input.parse()?;
 
                 match &*ident.to_string() {
                     "binds" => {
@@ -400,7 +383,7 @@ fn monotonic_args(path: Path, tokens: TokenStream2) -> parse::Result<MonotonicAr
                             ));
                         }
                         // Parse identifier name
-                        let ident = content.parse()?;
+                        let ident = input.parse()?;
 
                         binds = Some(ident);
                     }
@@ -414,7 +397,7 @@ fn monotonic_args(path: Path, tokens: TokenStream2) -> parse::Result<MonotonicAr
                         }
 
                         // #lit
-                        let lit: LitInt = content.parse()?;
+                        let lit: LitInt = input.parse()?;
 
                         if !lit.suffix().is_empty() {
                             return Err(parse::Error::new(
@@ -442,7 +425,7 @@ fn monotonic_args(path: Path, tokens: TokenStream2) -> parse::Result<MonotonicAr
                             ));
                         }
 
-                        let lit: LitBool = content.parse()?;
+                        let lit: LitBool = input.parse()?;
                         default = Some(lit.value);
                     }
 
@@ -450,22 +433,19 @@ fn monotonic_args(path: Path, tokens: TokenStream2) -> parse::Result<MonotonicAr
                         return Err(parse::Error::new(ident.span(), "unexpected argument"));
                     }
                 }
-                if content.is_empty() {
+                if input.is_empty() {
                     break;
                 }
 
                 // Handle comma: ,
-                let _: Token![,] = content.parse()?;
+                let _: Token![,] = input.parse()?;
             }
         }
 
         let binds = if let Some(r) = binds {
             r
         } else {
-            return Err(parse::Error::new(
-                content.span(),
-                "`binds = ...` is missing",
-            ));
+            return Err(parse::Error::new(error_loc, "`binds = ...` is missing"));
         };
         let default = default.unwrap_or(false);
 

--- a/src/parse/app.rs
+++ b/src/parse/app.rs
@@ -202,7 +202,9 @@ impl App {
                         .iter()
                         .position(|attr| util::attr_eq(attr, "init"))
                     {
-                        let args = InitArgs::parse(item.attrs.remove(pos).tokens)?;
+                        let args = InitArgs::parse(
+                            item.attrs.remove(pos).parse_args().unwrap_or_default(),
+                        )?;
 
                         // If an init function already exists, error
                         if init.is_some() {
@@ -220,7 +222,9 @@ impl App {
                         .iter()
                         .position(|attr| util::attr_eq(attr, "idle"))
                     {
-                        let args = IdleArgs::parse(item.attrs.remove(pos).tokens)?;
+                        let args = IdleArgs::parse(
+                            item.attrs.remove(pos).parse_args().unwrap_or_default(),
+                        )?;
 
                         // If an idle function already exists, error
                         if idle.is_some() {
@@ -247,7 +251,10 @@ impl App {
                             ));
                         }
 
-                        match crate::parse::task_args(item.attrs.remove(pos).tokens, settings)? {
+                        match crate::parse::task_args(
+                            item.attrs.remove(pos).parse_args().unwrap_or_default(),
+                            settings,
+                        )? {
                             Either::Left(args) => {
                                 check_binding(&args.binds)?;
                                 check_ident(&item.sig.ident)?;
@@ -405,7 +412,7 @@ impl App {
                                 }
 
                                 match crate::parse::task_args(
-                                    item.attrs.remove(pos).tokens,
+                                    item.attrs.remove(pos).parse_args().unwrap_or_default(),
                                     settings,
                                 )? {
                                     Either::Left(args) => {

--- a/src/parse/monotonic.rs
+++ b/src/parse/monotonic.rs
@@ -10,7 +10,7 @@ use crate::{
 
 impl MonotonicArgs {
     pub(crate) fn parse(attr: Attribute) -> parse::Result<Self> {
-        crate::parse::monotonic_args(attr.path, attr.tokens)
+        crate::parse::monotonic_args(attr.path().span(), attr.parse_args()?)
     }
 }
 
@@ -27,7 +27,7 @@ impl Monotonic {
 
         if !attrs.is_empty() {
             return Err(parse::Error::new(
-                attrs[0].path.span(),
+                attrs[0].path().span(),
                 "Monotonic does not support attributes other than `#[cfg]`",
             ));
         }

--- a/src/parse/util.rs
+++ b/src/parse/util.rs
@@ -3,8 +3,8 @@ use syn::{
     parse::{self, ParseStream},
     punctuated::Punctuated,
     spanned::Spanned,
-    Abi, AttrStyle, Attribute, Expr, FnArg, ForeignItemFn, Ident, ItemFn, Pat, PatType, Path,
-    PathArguments, ReturnType, Token, Type, Visibility,
+    Abi, AttrStyle, Attribute, Expr, ExprPath, FnArg, ForeignItemFn, Ident, ItemFn, Pat, PatType,
+    Path, PathArguments, ReturnType, Token, Type, Visibility,
 };
 
 use crate::{
@@ -20,8 +20,8 @@ pub fn abi_is_rust(abi: &Abi) -> bool {
 }
 
 pub fn attr_eq(attr: &Attribute, name: &str) -> bool {
-    attr.style == AttrStyle::Outer && attr.path.segments.len() == 1 && {
-        let segment = attr.path.segments.first().unwrap();
+    attr.style == AttrStyle::Outer && attr.path().segments.len() == 1 && {
+        let segment = attr.path().segments.first().unwrap();
         segment.arguments == PathArguments::None && *segment.ident.to_string() == *name
     }
 }
@@ -143,89 +143,138 @@ fn extract_resource_name_ident(path: Path) -> parse::Result<Ident> {
 }
 
 pub fn parse_local_resources(content: ParseStream<'_>) -> parse::Result<LocalResources> {
-    let inner;
-    bracketed!(inner in content);
+    let input;
+    bracketed!(input in content);
 
     let mut resources = Map::new();
 
-    for e in inner.call(Punctuated::<Expr, Token![,]>::parse_terminated)? {
-        let err = Err(parse::Error::new(
-            e.span(),
-            "identifier appears more than once in list",
-        ));
+    let error_msg_no_local_resources =
+        "malformed, expected 'local = [EXPRPATH: TYPE = EXPR]', or 'local = [EXPRPATH, ...]'";
 
-        let (name, local) = match e {
-            // local = [IDENT],
-            Expr::Path(path) => {
-                if !path.attrs.is_empty() {
-                    return Err(parse::Error::new(
-                        path.span(),
-                        "attributes are not supported here",
-                    ));
-                }
+    loop {
+        if input.is_empty() {
+            break;
+        }
+        // Type ascription is de-RFCd from Rust in
+        // https://github.com/rust-lang/rfcs/pull/3307
+        // Manually pull out the tokens
 
-                let ident = extract_resource_name_ident(path.path)?;
-                // let (cfgs, attrs) = extract_cfgs(path.attrs);
+        // Two acceptable variants:
+        //
+        // Task local and declared (initialized in place)
+        // local = [EXPRPATH: TYPE = EXPR, ...]
+        //          ~~~~~~~~~~~~~~~~~~~~~~
+        // or
+        // Task local but not initialized
+        // local = [EXPRPATH, ...],
+        //          ~~~~~~~~~
 
-                (ident, TaskLocal::External)
-            }
+        // Common: grab first identifier EXPRPATH
+        // local = [EXPRPATH: TYPE = EXPR, ...]
+        //          ~~~~~~~~
+        let exprpath: ExprPath = input.parse()?;
 
-            // local = [IDENT: TYPE = EXPR]
-            Expr::Assign(e) => {
-                let (name, ty, cfgs, attrs) = match *e.left {
-                    Expr::Type(t) => {
-                        // Extract name and attributes
-                        let (name, cfgs, attrs) = match *t.expr {
-                            Expr::Path(path) => {
-                                let name = extract_resource_name_ident(path.path)?;
-                                let FilterAttrs { cfgs, attrs, .. } = filter_attributes(path.attrs);
+        let name = extract_resource_name_ident(exprpath.path)?;
 
-                                (name, cfgs, attrs)
-                            }
-                            _ => return err,
-                        };
-
-                        let ty = t.ty;
-
-                        // Error check
-                        match &*ty {
-                            Type::Array(_) => {}
-                            Type::Path(_) => {}
-                            Type::Ptr(_) => {}
-                            Type::Tuple(_) => {}
-                            _ => return Err(parse::Error::new(
-                                ty.span(),
-                                "unsupported type, must be an array, tuple, pointer or type path",
-                            )),
-                        };
-
-                        (name, ty, cfgs, attrs)
-                    }
-                    e => return Err(parse::Error::new(e.span(), "malformed, expected a type")),
-                };
-
-                let expr = e.right; // Expr
-
-                (
-                    name,
-                    TaskLocal::Declared(Local {
-                        attrs,
-                        cfgs,
-                        ty,
-                        expr,
-                    }),
-                )
-            }
-
-            expr => {
-                return Err(parse::Error::new(
-                    expr.span(),
-                    "malformed, expected 'IDENT: TYPE = EXPR'",
-                ))
-            }
+        // Extract attributes
+        let ExprPath { attrs, .. } = exprpath;
+        let (cfgs, attrs) = {
+            let FilterAttrs { cfgs, attrs, .. } = filter_attributes(attrs);
+            (cfgs, attrs)
         };
 
+        let local;
+
+        // Declared requries type ascription
+        if input.peek(Token![:]) {
+            // Handle colon
+            let _: Token![:] = input.parse()?;
+
+            // Extract the type
+            let ty: Box<Type> = input.parse()?;
+
+            if input.peek(Token![=]) {
+                // Handle equal sign
+                let _: Token![=] = input.parse()?;
+            } else {
+                return Err(parse::Error::new(
+                    name.span(),
+                    "malformed, expected 'IDENT: TYPE = EXPR'",
+                ));
+            }
+
+            // Grab the final expression right of equal
+            let expr: Box<Expr> = input.parse()?;
+
+            // We got a trailing comma, remove it
+            if input.peek(Token![,]) {
+                let _: Token![,] = input.parse()?;
+            }
+
+            // Error check
+            match &*ty {
+                Type::Array(_) => {}
+                Type::Path(_) => {}
+                Type::Ptr(_) => {}
+                Type::Tuple(_) => {}
+                _ => {
+                    return Err(parse::Error::new(
+                        ty.span(),
+                        "unsupported type, must be an array, tuple, pointer or type path",
+                    ))
+                }
+            };
+
+            local = TaskLocal::Declared(Local {
+                attrs,
+                cfgs,
+                ty,
+                expr,
+            });
+        } else if input.peek(Token![=]) {
+            // Missing type ascription is not valid
+            return Err(parse::Error::new(name.span(), "malformed, expected a type"));
+        } else if input.peek(Token![,]) {
+            // Attributes not supported on non-initialized local resources!
+
+            if !attrs.is_empty() {
+                return Err(parse::Error::new(
+                    name.span(),
+                    "attributes are not supported here",
+                ));
+            }
+
+            // Remove comma
+            let _: Token![,] = input.parse()?;
+
+            // Expected when multiple local resources
+            local = TaskLocal::External;
+        } else if input.is_empty() {
+            // There was only one single local resource
+            // Task local but not initialized
+            // local = [EXPRPATH],
+            //          ~~~~~~~~
+            local = TaskLocal::External;
+        } else {
+            // Specifying local without any resources is invalid
+            return Err(parse::Error::new(name.span(), error_msg_no_local_resources));
+        };
+
+        if resources.contains_key(&name) {
+            return Err(parse::Error::new(
+                name.span(),
+                "resource appears more than once in list",
+            ));
+        }
+
         resources.insert(name, local);
+    }
+
+    if resources.is_empty() {
+        return Err(parse::Error::new(
+            input.span(),
+            error_msg_no_local_resources,
+        ));
     }
 
     Ok(resources)

--- a/ui/local-malformed-1.stderr
+++ b/ui/local-malformed-1.stderr
@@ -1,4 +1,4 @@
-error: unexpected end of input, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
+error: unexpected end of input, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, `dyn`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
   --> ui/local-malformed-1.rs:11:23
    |
 11 |     #[task(local = [a:])]

--- a/ui/local-malformed-3.stderr
+++ b/ui/local-malformed-3.stderr
@@ -1,4 +1,4 @@
-error: unexpected end of input, expected expression
+error: unexpected end of input, expected an expression
   --> ui/local-malformed-3.rs:11:29
    |
 11 |     #[task(local = [a: u32 =])]

--- a/ui/local-shared-attribute.stderr
+++ b/ui/local-shared-attribute.stderr
@@ -1,5 +1,5 @@
 error: attributes are not supported here
- --> $DIR/local-shared-attribute.rs:8:9
+ --> ui/local-shared-attribute.rs:9:9
   |
-8 |         #[test]
+9 |         b, // Error
   |         ^

--- a/ui/monotonic-no-binds.stderr
+++ b/ui/monotonic-no-binds.stderr
@@ -1,5 +1,5 @@
 error: `binds = ...` is missing
- --> $DIR/monotonic-no-binds.rs:5:17
+ --> ui/monotonic-no-binds.rs:5:7
   |
 5 |     #[monotonic()]
-  |                 ^
+  |       ^^^^^^^^^

--- a/ui/monotonic-no-paran.stderr
+++ b/ui/monotonic-no-paran.stderr
@@ -1,4 +1,4 @@
-error: expected opening ( in #[monotonic( ... )]
+error: expected attribute arguments in parentheses: #[monotonic(...)]
  --> ui/monotonic-no-paran.rs:5:7
   |
 5 |     #[monotonic]


### PR DESCRIPTION
Upgrade the dependency `syn` crate to version 2.x. Update the macro parsing code to work with syn 2.x API.

I have copied the macro parsing code from [RTIC version 2.x](https://github.com/rtic-rs/rtic), where possible.

These are part of changes to be able to use Rust edition 2024 with RTIC version 1.x.
